### PR TITLE
Make GCC gcov version consistent with the visible version of default gcc & g++

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ add-apt-repository ppa:ubuntu-toolchain-r/test
 apt-get update
 apt-get install gcc-6 g++-6
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 50 --slave /usr/bin/g++ g++ /usr/bin/g++-6
+update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-6 50
 gcc --version
 echo "================== Successfully Installed gcc 6 ==============="
 


### PR DESCRIPTION
There is an `update-alternatives` call for g++ to point to g++-6, but the default version of gcov remains pointing to the default (older) version, causing problems when running coverage tests. 

This patch simply also updates gcov to the version matching gcc/g++.
