### PR TITLE
update README for gcc version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@ u16cppall
 
 Shippable CI image for C++ on Ubuntu 16.04. Available GCC and Clang versions:
 
-   1. gcc: 7.0
+   1. gcc: 7.1.0
    2. clang: 4.0.0


### PR DESCRIPTION
https://github.com/dry-dock/u16cppall/issues/13

version already updated but readme wasn't